### PR TITLE
Dev: Use vite and travis to deploy app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js:
+  - lts/*
+install:
+  - npm ci
+script:
+  - npm run build
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: dist
+  # A token generated on GitHub allowing Travis to push code on you repository.
+  # Set in the Travis settings page of your repository, as a secure variable.
+  github_token: $GITHUB_TOKEN
+  keep_history: true
+  on:
+    branch: main

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+// vite.config.js
+export default {
+  // config options
+
+  // https://vitejs.dev/guide/static-deploy.html#github-pages
+  base: "/viewshed-peaks/"
+};


### PR DESCRIPTION
Use vite and Travis CI to deploy the app to GH pages

See https://vitejs.dev/guide/static-deploy.html#github-pages for details