### PR TITLE
Test: Resolve dependencies with `--legacy-peer-deps`

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,5 +27,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
       - run: npm run build


### PR DESCRIPTION
Error introduced after bug fix in npm v8.6